### PR TITLE
Added tetrinos spawning in the middle of the board

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Tetris game written in JS that runs in JS console in your browser. Live demo ava
 
 ## TODO
 ### Gameplay
-- spawn tetrinos at the middle of X axis
+- ~~spawn tetrinos at the middle of X axis~~
 - spawn all tetrinos at the very top of the board
 
 ### Technicalities

--- a/src/game/board.js
+++ b/src/game/board.js
@@ -1,5 +1,6 @@
 const { Directions } = require('./constants');
 const Matrix = require('./matrix');
+const Point = require('./point');
 const Tetrino = require('./tetrino');
 
 class Board {
@@ -12,7 +13,15 @@ class Board {
 	reset() {
 		this.matrix = new Matrix(this.sizeX, this.sizeY);
 		this.tetrino = undefined;
-    this.nextTetrino = new Tetrino();
+    	this.nextTetrino = new Tetrino();
+	}
+
+	moveTetrinoIntoPosition(tetrinoToMove) {
+		var newTertino = tetrinoToMove;
+		newTertino.calculateMovement();
+		var coords = newTertino.getCoordinates().map(coordinate => new Point(coordinate.x + Math.floor( (this.sizeX/2)) -2, coordinate.y))
+		newTertino.setCoordinates(coords);
+		return newTertino ;
 	}
 
 	getTetrino() {
@@ -32,7 +41,7 @@ class Board {
 	}
 
 	spawnTetrino() {
-		this.tetrino = this.nextTetrino;
+		this.tetrino = this.moveTetrinoIntoPosition(this.nextTetrino);
     this.nextTetrino = new Tetrino();
     this.drawTetrinoOnMatrix();
   }


### PR DESCRIPTION
This commit adds a function that centres newly spawned tetrinos at the centre of the board.

Had to add -2 magic number offset to account for the offset in the tetrino models